### PR TITLE
More rigorous Source argument checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,140 @@
+# Byte-compiled / optimized / DLL files
 __pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
 .DS_Store

--- a/calcs/utils.py
+++ b/calcs/utils.py
@@ -219,12 +219,8 @@ def determine_stationarity(m_1, m_2, forb_i, t_evol, ecc, stat_tol=1e-2):
     merged = inner_part < 0.0
     inspiral = np.logical_not(merged)
 
-    delta_f = np.zeros(len(forb_i)) * u.Hz
-
-    # calculate the final frequency (set to 1 Hz if merged)
-    delta_f[merged] = 1e10 * u.Hz
-    delta_f[inspiral] = np.power(inner_part[inspiral], -3/8) - forb_i[inspiral]
-
+    # calculate the change in frequency (set to 10^10 Hz if merged)
+    delta_f = np.where(merged, 1e10 * u.Hz, np.power(inner_part[inspiral], -3/8) - forb_i[inspiral])
     stationary = delta_f / forb_i <= stat_tol
 
     return stationary


### PR DESCRIPTION
Main reason for PR is now you can call Source with a single source without any errors. While I was at it, I've changed the `__init__` function so that it is a bit more careful with the input and performs the following checks:

1. At least one of `f_orb` and `a` exists (this was there before but just highlighting)
2. All variable that _should_ have units (`m_1, m_2, dist, f_orb, a`) do have units
3. All variable that _should_ be arrays (`m_1, m_2, dist, f_orb, a, ecc`) are in arrays and each of those arrays are the **same length**

(I also changed the .gitignore to a [default Python development one](https://github.com/github/gitignore/blob/master/Python.gitignore))