### PR TITLE
g(n,e) vectorisation and interpolation!

### DIFF
--- a/calcs/evol.py
+++ b/calcs/evol.py
@@ -28,8 +28,8 @@ def de_dt(beta, c_0, e):
     dedt : `array`
         eccentricity evolution
     """
-    dedt = -19/12 * beta/c_0**4 * (e**(29/19)*(1 - e**2)**(3/2))/\
-                                   (1+(121/304)*e**2)**(1181/2299)
+    dedt = -19/12 * beta/c_0**4 * (e**(29/19)*(1 - e**2)**(3/2)) \
+                                / (1+(121/304)*e**2)**(1181/2299)
 
     return dedt
 
@@ -104,7 +104,7 @@ def get_e_evol(beta, c_0, ecc_i, times):
 
     e_evol = odeint(ecc_i, times, args=(beta.value, c_0.value))
 
-    return e_evol.flatten() 
+    return e_evol.flatten()
 
 
 def get_f_and_e(m_1, m_2, f_orb_i, e_i, t_evol, circ_tol, n_step):
@@ -160,7 +160,7 @@ def get_f_and_e(m_1, m_2, f_orb_i, e_i, t_evol, circ_tol, n_step):
 
     a_evol = get_a_evol(a_i=a_i, e_i=e_i, e_evol=e_evol,
                         beta=beta, c_0=c_0, times=times)
-    
+
     # change merged binaries to extremely small separations
     a_evol = np.where(a_evol.value == 0.0, 1e-30 * a_evol.unit, a_evol)
     f_orb_evol = utils.get_f_orb_from_a(a=a_evol, m_1=m_1, m_2=m_2)

--- a/calcs/lisa.py
+++ b/calcs/lisa.py
@@ -5,6 +5,7 @@ import astropy.units as u
 from scipy.interpolate import splev, splrep
 from importlib import resources
 
+
 def load_transfer_function(f, fstar=19.09e-3):
     """Load in transfer function from file and interpolate values
     for a range of frequencies. Adapted from
@@ -29,7 +30,8 @@ def load_transfer_function(f, fstar=19.09e-3):
         with resources.path(package="calcs", resource="R.npy") as path:
             f_R, R = np.load(path)
     except FileExistsError:
-        print("WARNING: Can't find transfer function file, using approximation instead")
+        print("WARNING: Can't find transfer function file, \
+                        using approximation instead")
         return approximate_transfer_function(f, fstar)
 
     # interpolate the R values in the file
@@ -38,6 +40,7 @@ def load_transfer_function(f, fstar=19.09e-3):
     # use interpolated curve to get R values for supplied f values
     R = splev(f, R_data, der=0)
     return R
+
 
 def approximate_transfer_function(f, fstar):
     """Calculate the the LISA transfer function using
@@ -58,7 +61,10 @@ def approximate_transfer_function(f, fstar):
     """
     return (3 / 10) / (1 + 0.6 * (f / fstar)**2)
 
-def power_spectral_density(f, t_obs=4*u.yr, L=2.5e9, fstar=19.09e-3, approximate_R=False, include_confusion_noise=True):
+
+def power_spectral_density(f, t_obs=4*u.yr, L=2.5e9, fstar=19.09e-3,
+                           approximate_R=False,
+                           include_confusion_noise=True):
     """Calculates the effective LISA power spectral density sensitivity
     curve using equations from Robson+19
 
@@ -78,10 +84,10 @@ def power_spectral_density(f, t_obs=4*u.yr, L=2.5e9, fstar=19.09e-3, approximate
 
     approximate_R : `boolean`
         whether to approximate the transfer function (default: no)
-    
+
     include_confusion_noise  : `boolean`
         whether to include the Galactic confusion noise (default: yes)
-    
+
     Returns
     -------
     Sn : `float/array`
@@ -136,8 +142,8 @@ def power_spectral_density(f, t_obs=4*u.yr, L=2.5e9, fstar=19.09e-3, approximate
             gamma = 1680.
             fk = 1.13e-3
 
-        return 9e-45 * f**(-7/3.) * np.exp(-f**(alpha) + beta * f \
-                * np.sin(kappa * f)) * (1 + np.tanh(gamma * (fk - f)))
+        return 9e-45 * f**(-7/3.) * np.exp(-f**(alpha) + beta * f
+                     * np.sin(kappa * f)) * (1 + np.tanh(gamma * (fk - f)))
 
     # calculate transfer function (either exactly or with approximation)
     if approximate_R:
@@ -149,10 +155,10 @@ def power_spectral_density(f, t_obs=4*u.yr, L=2.5e9, fstar=19.09e-3, approximate
     if include_confusion_noise:
         cn = Sc(f, t_obs)
     else:
-        cn = np.zeros(len(f)) if isinstance(f, list) or isinstance(f, np.ndarray) else 0.0
+        cn = np.zeros(len(f)) if isinstance(f, (list, np.ndarray)) else 0.0
 
     # calculate sensitivity curve
-    Sn = (1 / (L**2) * (Poms(f) + 4 * Pacc(f) / (2 * np.pi * f)**4)) / R  + cn
+    Sn = (1 / (L**2) * (Poms(f) + 4 * Pacc(f) / (2 * np.pi * f)**4)) / R + cn
 
     # replace values for bad frequencies (set to extremely high value)
     Sn = np.where(np.logical_and(f > MIN_F, f < MAX_F), Sn, HUGE_NOISE)

--- a/calcs/snr.py
+++ b/calcs/snr.py
@@ -8,7 +8,7 @@ import calcs.utils as utils
 import calcs.evol as evol
 
 
-def snr_circ_stationary(m_c, f_orb, dist, t_obs):
+def snr_circ_stationary(m_c, f_orb, dist, t_obs, interpolated_g=None):
     """Computes the signal to noise ratio for stationary and
     circular binaries
 
@@ -26,6 +26,13 @@ def snr_circ_stationary(m_c, f_orb, dist, t_obs):
     t_obs : `float`
         total duration of the observation
 
+    interpolated_g : `function`
+        A function returned by scipy.interpolate.interp2d that
+        computes g(n,e) from Peters (1964). The code assumes
+        that the function returns the output sorted as with the
+        interp2d returned functions (and thus unsorts).
+        Default is None and uses exact g(n,e) in this case.
+
     Returns
     -------
     sn : `float/array`
@@ -33,11 +40,9 @@ def snr_circ_stationary(m_c, f_orb, dist, t_obs):
     """
 
     # only need to compute n=2 harmonic for circular
-    h_0_circ_2 = strain.h_0_n(m_c=m_c,
-                                f_orb=f_orb, 
-                                ecc=0.0,
-                                n=2, 
-                                dist=dist).flatten()**2
+    h_0_circ_2 = strain.h_0_n(m_c=m_c, f_orb=f_orb, 
+                              ecc=0.0, n=2, dist=dist,
+                              interpolated_g=interpolated_g).flatten()**2
 
     h_f_src_circ_2 = h_0_circ_2 * t_obs
     h_f_lisa_2 = lisa.power_spectral_density(f=2 * f_orb, t_obs=t_obs)
@@ -46,7 +51,7 @@ def snr_circ_stationary(m_c, f_orb, dist, t_obs):
     return snr.decompose()
 
 
-def snr_ecc_stationary(m_c, f_orb, ecc, dist, t_obs, max_harmonic):
+def snr_ecc_stationary(m_c, f_orb, ecc, dist, t_obs, max_harmonic, interpolated_g=None):
     """Computes the signal to noise ratio for stationary and
     eccentric binaries
 
@@ -71,6 +76,13 @@ def snr_ecc_stationary(m_c, f_orb, ecc, dist, t_obs, max_harmonic):
     max_harmonic : `integer`
         maximum integer harmonic to compute
 
+    interpolated_g : `function`
+        A function returned by scipy.interpolate.interp2d that
+        computes g(n,e) from Peters (1964). The code assumes
+        that the function returns the output sorted as with the
+        interp2d returned functions (and thus unsorts).
+        Default is None and uses exact g(n,e) in this case.
+
     Returns
     -------
     sn : `float/array`
@@ -81,7 +93,8 @@ def snr_ecc_stationary(m_c, f_orb, ecc, dist, t_obs, max_harmonic):
 
     # calculate source signal
     h_0_ecc_n_2 = strain.h_0_n(m_c=m_c, f_orb=f_orb,
-                               ecc=ecc, n=n_range, dist=dist)**2
+                               ecc=ecc, n=n_range, dist=dist,
+                               interpolated_g=interpolated_g)**2
     h_f_src_ecc_2 = h_0_ecc_n_2 * t_obs
 
     # turn n_range into grid and calcualte noise
@@ -93,7 +106,7 @@ def snr_ecc_stationary(m_c, f_orb, ecc, dist, t_obs, max_harmonic):
     return snr.decompose()
 
 
-def snr_circ_evolving(m_1, m_2, f_orb_i, dist, t_obs, n_step):
+def snr_circ_evolving(m_1, m_2, f_orb_i, dist, t_obs, n_step, interpolated_g=None):
     """Computes the signal to noise ratio for stationary and
     circular binaries
 
@@ -116,6 +129,13 @@ def snr_circ_evolving(m_1, m_2, f_orb_i, dist, t_obs, n_step):
 
     n_step : `int`
         number of timesteps during obsrvation duration
+
+    interpolated_g : `function`
+        A function returned by scipy.interpolate.interp2d that
+        computes g(n,e) from Peters (1964). The code assumes
+        that the function returns the output sorted as with the
+        interp2d returned functions (and thus unsorts).
+        Default is None and uses exact g(n,e) in this case.
 
     Returns
     -------
@@ -145,7 +165,8 @@ def snr_circ_evolving(m_1, m_2, f_orb_i, dist, t_obs, n_step):
                            f_orb=f_evol,
                            ecc=np.zeros(len(m_c)),
                            n=2,
-                           dist=dist)**2
+                           dist=dist,
+                           interpolated_g=interpolated_g)**2
     # calculate the characteristic noise power
     h_f_lisa_2 = lisa.power_spectral_density(f=2 * f_evol, t_obs=t_obs)
     h_c_lisa_2 = 4 * (2*f_evol)**2 * h_f_lisa_2
@@ -154,7 +175,7 @@ def snr_circ_evolving(m_1, m_2, f_orb_i, dist, t_obs, n_step):
 
     return snr.decompose()
 
-def snr_ecc_evolving(m_1, m_2, f_orb_i, dist, ecc, max_harmonic, t_obs, n_step):
+def snr_ecc_evolving(m_1, m_2, f_orb_i, dist, ecc, max_harmonic, t_obs, n_step, interpolated_g=None):
     """Computes the signal to noise ratio for stationary and
     eccentric binaries
 
@@ -184,6 +205,13 @@ def snr_ecc_evolving(m_1, m_2, f_orb_i, dist, ecc, max_harmonic, t_obs, n_step):
 
     n_step : `int`
         number of timesteps during obsrvation duration
+
+    interpolated_g : `function`
+        A function returned by scipy.interpolate.interp2d that
+        computes g(n,e) from Peters (1964). The code assumes
+        that the function returns the output sorted as with the
+        interp2d returned functions (and thus unsorts).
+        Default is None and uses exact g(n,e) in this case.
 
     Returns
     -------

--- a/calcs/snr.py
+++ b/calcs/snr.py
@@ -85,8 +85,8 @@ def snr_ecc_stationary(m_c, f_orb, ecc, dist, t_obs, max_harmonic):
     h_f_src_ecc_2 = h_0_ecc_n_2 * t_obs
 
     # turn n_range into grid and calcualte noise
-    N, _ = np.meshgrid(n_range, ecc)
-    h_f_lisa_n_2 = lisa.power_spectral_density(f=N * f_orb, t_obs=t_obs)
+    N, F = np.meshgrid(n_range, f_orb)
+    h_f_lisa_n_2 = lisa.power_spectral_density(f=N * F, t_obs=t_obs)
 
     # calculate the signal-to-noise ratio
     snr = (np.sum(h_f_src_ecc_2 / (4*h_f_lisa_n_2), axis=1))**0.5

--- a/calcs/snr.py
+++ b/calcs/snr.py
@@ -1,7 +1,6 @@
 """`snr calcs` for gw calcs"""
 
 import numpy as np
-import astropy.units as u
 import calcs.strain as strain
 import calcs.lisa as lisa
 import calcs.utils as utils
@@ -40,7 +39,7 @@ def snr_circ_stationary(m_c, f_orb, dist, t_obs, interpolated_g=None):
     """
 
     # only need to compute n=2 harmonic for circular
-    h_0_circ_2 = strain.h_0_n(m_c=m_c, f_orb=f_orb, 
+    h_0_circ_2 = strain.h_0_n(m_c=m_c, f_orb=f_orb,
                               ecc=0.0, n=2, dist=dist,
                               interpolated_g=interpolated_g).flatten()**2
 
@@ -51,7 +50,8 @@ def snr_circ_stationary(m_c, f_orb, dist, t_obs, interpolated_g=None):
     return snr.decompose()
 
 
-def snr_ecc_stationary(m_c, f_orb, ecc, dist, t_obs, max_harmonic, interpolated_g=None):
+def snr_ecc_stationary(m_c, f_orb, ecc, dist, t_obs, max_harmonic,
+                       interpolated_g=None):
     """Computes the signal to noise ratio for stationary and
     eccentric binaries
 
@@ -106,7 +106,8 @@ def snr_ecc_stationary(m_c, f_orb, ecc, dist, t_obs, max_harmonic, interpolated_
     return snr.decompose()
 
 
-def snr_circ_evolving(m_1, m_2, f_orb_i, dist, t_obs, n_step, interpolated_g=None):
+def snr_circ_evolving(m_1, m_2, f_orb_i, dist, t_obs, n_step,
+                      interpolated_g=None):
     """Computes the signal to noise ratio for stationary and
     circular binaries
 
@@ -171,11 +172,14 @@ def snr_circ_evolving(m_1, m_2, f_orb_i, dist, t_obs, n_step, interpolated_g=Non
     h_f_lisa_2 = lisa.power_spectral_density(f=2 * f_evol, t_obs=t_obs)
     h_c_lisa_2 = 4 * (2*f_evol)**2 * h_f_lisa_2
 
-    snr = (np.sum(h_c_n_2[:-1] / h_c_lisa_2[:-1] * (f_evol[1:] - f_evol[:-1]), axis=0))**(0.5)
+    snr = (np.sum(h_c_n_2[:-1] / h_c_lisa_2[:-1] * (f_evol[1:] - f_evol[:-1]),
+                  axis=0))**(0.5)
 
     return snr.decompose()
 
-def snr_ecc_evolving(m_1, m_2, f_orb_i, dist, ecc, max_harmonic, t_obs, n_step, interpolated_g=None):
+
+def snr_ecc_evolving(m_1, m_2, f_orb_i, dist, ecc, max_harmonic, t_obs, n_step,
+                     interpolated_g=None):
     """Computes the signal to noise ratio for stationary and
     eccentric binaries
 

--- a/calcs/source.py
+++ b/calcs/source.py
@@ -5,6 +5,7 @@ from importlib import resources
 from scipy.interpolate import interp1d, interp2d
 
 import calcs.utils as utils
+import calcs.strain as strain
 import calcs.snr as sn
 
 __all__ = ['Source', 'Stationary', 'Evolving']
@@ -235,6 +236,40 @@ class Source():
             raise ValueError("`stationary` must be None, True or False")
 
         return np.logical_and(circular_mask, stationary_mask)
+
+    def get_h_0_n(self, harmonics):
+        """Computes the strain for all binaries for the given `harmonics`
+
+        Params
+        ------
+        harmonics : `int/array`
+            harmonic(s) at which to calculate the strain
+
+        Returns
+        -------
+        h_0_n : `float/array`
+            dimensionless strain in the quadrupole approximation (unitless)
+            shape of array is `(number of sources, number of harmonics)`
+        """
+        return strain.h_0_n(utils.chirp_mass(self.m_1, self.m_2), self.f_orb,
+                            self.ecc, harmonics, self.dist)
+
+    def get_h_c_n(self, harmonics):
+        """Computes the characteristic strain for all binaries for the given `harmonics`
+
+        Params
+        ------
+        harmonics : `int/array`
+            harmonic(s) at which to calculate the strain
+
+        Returns
+        -------
+        h_c_n : `float/array`
+            dimensionless characteristic strain in the quadrupole approximation (unitless)
+            shape of array is `(number of sources, number of harmonics)`
+        """
+        return strain.h_c_n(utils.chirp_mass(self.m_1, self.m_2), self.f_orb,
+                            self.ecc, harmonics, self.dist)
 
     def get_snr(self, t_obs=4 * u.yr, n_step=100, verbose=False):
         """Computes the SNR for a generic binary

--- a/calcs/source.py
+++ b/calcs/source.py
@@ -348,7 +348,8 @@ class Source():
             snr[ind_circ] = sn.snr_circ_stationary(m_c=m_c[ind_circ], 
                                                    f_orb=self.f_orb[ind_circ], 
                                                    dist=self.dist[ind_circ], 
-                                                   t_obs=t_obs)
+                                                   t_obs=t_obs,
+                                                   interpolated_g=self.g)
         if ind_ecc.any():
             if verbose:
                 print("\t\t{} sources are stationary and eccentric".format(
@@ -363,7 +364,8 @@ class Source():
                                                         ecc=self.ecc[matching],
                                                         dist=self.dist[matching],
                                                         t_obs=t_obs,
-                                                        max_harmonic=upper - 1)
+                                                        max_harmonic=upper - 1,
+                                                        interpolated_g=self.g)
 
         return snr[which_sources]
 
@@ -407,7 +409,8 @@ class Source():
                                                  f_orb_i=self.f_orb[ind_circ],
                                                  dist=self.dist[ind_circ],
                                                  t_obs=t_obs,
-                                                 n_step=n_step)
+                                                 n_step=n_step,
+                                                 interpolated_g=self.g)
         if ind_ecc.any():
             if verbose:
                 print("\t\t{} sources are evolving and eccentric".format(
@@ -424,7 +427,8 @@ class Source():
                                                         ecc=self.ecc[matching],
                                                         max_harmonic=upper - 1,
                                                         t_obs=t_obs,
-                                                        n_step=n_step)
+                                                        n_step=n_step,
+                                                        interpolated_g=self.g)
 
         return snr[which_sources]
 

--- a/calcs/strain.py
+++ b/calcs/strain.py
@@ -34,8 +34,8 @@ def h_0_n(m_c, f_orb, ecc, n, dist):
         shape of array is `(number of sources, number of harmonics)`
     """
     # calculate how many harmonics and sources
-    n_harmonics = 1 if isinstance(n, int) else len(n)
-    n_sources = len(m_c) if isinstance(m_c.value, np.ndarray) else 1
+    n_harmonics = 1 if isinstance(n, (int, np.int64, np.int)) else len(n)
+    n_sources = len(m_c) if isinstance(m_c.value, (list, np.ndarray)) else 1
 
     # work out strain for n independent part and broadcast to correct shape
     prefac = (2**(28/3) / 5)**(0.5) * c.G**(5/3) / c.c**4
@@ -80,8 +80,8 @@ def h_c_n(m_c, f_orb, ecc, n, dist):
         dimensionless strain in the quadrupole approximation (unitless)
     """
     # calculate how many harmonics and sources
-    n_harmonics = 1 if isinstance(n, int) else len(n)
-    n_sources = len(m_c) if isinstance(m_c.value, np.ndarray) else 1
+    n_harmonics = 1 if isinstance(n, (int, np.int64, np.int)) else len(n)
+    n_sources = len(m_c) if isinstance(m_c.value, (list, np.ndarray)) else 1
 
     # work out strain for n independent part and broadcast to correct shape
     prefac = (2**(5/3) / (3 * np.pi**(4/3)))**(0.5) * c.G**(5/6) / c.c**(3/2)

--- a/calcs/strain.py
+++ b/calcs/strain.py
@@ -35,12 +35,15 @@ def h_0_n(m_c, f_orb, ecc, n, dist):
     """
     # calculate how many harmonics and sources
     n_harmonics = 1 if isinstance(n, (int, np.int64, np.int)) else len(n)
-    n_sources = len(m_c) if isinstance(m_c.value, (list, np.ndarray)) else 1
+    n_sources = len(f_orb) if isinstance(f_orb.value, (list, np.ndarray)) else 1
 
     # work out strain for n independent part and broadcast to correct shape
     prefac = (2**(28/3) / 5)**(0.5) * c.G**(5/3) / c.c**4
     n_independent_part = prefac * m_c**(5/3) * (np.pi * f_orb)**(2/3) / dist
-    n_independent_part = np.broadcast_to(n_independent_part.decompose(), (n_harmonics, n_sources)).T
+    
+    # broadcast to correct shape if necessary
+    if n_independent_part.shape != (n_sources, n_harmonics):
+        n_independent_part = np.broadcast_to(n_independent_part.decompose(), (n_harmonics, n_sources)).T
 
     N, E = np.meshgrid(n, ecc)
     n_dependent_part = peters_g(N, E)**(1/2) / N
@@ -81,12 +84,15 @@ def h_c_n(m_c, f_orb, ecc, n, dist):
     """
     # calculate how many harmonics and sources
     n_harmonics = 1 if isinstance(n, (int, np.int64, np.int)) else len(n)
-    n_sources = len(m_c) if isinstance(m_c.value, (list, np.ndarray)) else 1
+    n_sources = len(f_orb) if isinstance(f_orb.value, (list, np.ndarray)) else 1
 
-    # work out strain for n independent part and broadcast to correct shape
+    # work out strain for n independent part
     prefac = (2**(5/3) / (3 * np.pi**(4/3)))**(0.5) * c.G**(5/6) / c.c**(3/2)
     n_independent_part = prefac * m_c**(5/6) / dist * f_orb**(-1/6) / peters_f(ecc)**(0.5)
-    n_independent_part = np.broadcast_to(n_independent_part.decompose(), (n_harmonics, n_sources)).T
+
+    # broadcast to correct shape if necessary
+    if n_independent_part.shape != (n_sources, n_harmonics):
+        n_independent_part = np.broadcast_to(n_independent_part.decompose(), (n_harmonics, n_sources)).T
 
     N, E = np.meshgrid(n, ecc)
     n_dependent_part = (peters_g(N, E) / N)**(1/2)

--- a/calcs/strain.py
+++ b/calcs/strain.py
@@ -42,15 +42,16 @@ def h_0_n(m_c, f_orb, ecc, n, dist, interpolated_g=None):
     """
     # calculate how many harmonics and sources
     n_harmonics = 1 if isinstance(n, (int, np.int64, np.int)) else len(n)
-    n_sources = len(f_orb) if isinstance(f_orb.value, (list, np.ndarray)) else 1
+    n_sources = len(f_orb) if isinstance(f_orb.value, (list, np.ndarray))else 1
 
     # work out strain for n independent part and broadcast to correct shape
     prefac = (2**(28/3) / 5)**(0.5) * c.G**(5/3) / c.c**4
     n_independent_part = prefac * m_c**(5/3) * (np.pi * f_orb)**(2/3) / dist
-    
+
     # broadcast to correct shape if necessary
     if n_independent_part.shape != (n_sources, n_harmonics):
-        n_independent_part = np.broadcast_to(n_independent_part.decompose(), (n_harmonics, n_sources)).T
+        n_independent_part = np.broadcast_to(n_independent_part.decompose(),
+                                             (n_harmonics, n_sources)).T
 
     N, E = np.meshgrid(n, ecc)
 
@@ -107,15 +108,17 @@ def h_c_n(m_c, f_orb, ecc, n, dist, interpolated_g=None):
     """
     # calculate how many harmonics and sources
     n_harmonics = 1 if isinstance(n, (int, np.int64, np.int)) else len(n)
-    n_sources = len(f_orb) if isinstance(f_orb.value, (list, np.ndarray)) else 1
+    n_sources = len(f_orb) if isinstance(f_orb.value, (list, np.ndarray))else 1
 
     # work out strain for n independent part
     prefac = (2**(5/3) / (3 * np.pi**(4/3)))**(0.5) * c.G**(5/6) / c.c**(3/2)
-    n_independent_part = prefac * m_c**(5/6) / dist * f_orb**(-1/6) / peters_f(ecc)**(0.5)
+    n_independent_part = prefac * m_c**(5/6) / dist * f_orb**(-1/6) \
+                                / peters_f(ecc)**(0.5)
 
     # broadcast to correct shape if necessary
     if n_independent_part.shape != (n_sources, n_harmonics):
-        n_independent_part = np.broadcast_to(n_independent_part.decompose(), (n_harmonics, n_sources)).T
+        n_independent_part = np.broadcast_to(n_independent_part.decompose(),
+                                             (n_harmonics, n_sources)).T
 
     N, E = np.meshgrid(n, ecc)
     if interpolated_g is None:

--- a/calcs/tests/test_strains.py
+++ b/calcs/tests/test_strains.py
@@ -18,8 +18,8 @@ class Test(unittest.TestCase):
     def test_strain_conversion(self):
         """This test checks whether the strain and characteristic strain are
         related as hc^2 = (2 * fn^2 / fn_dot) h0^2"""
-        h0 = strain.h_0_n(m_c, f_orb, e, n, dist)
-        hc = strain.h_c_n(m_c, f_orb, e, n, dist)
+        h0 = strain.h_0_n(m_c, f_orb, e, n, dist).flatten()
+        hc = strain.h_c_n(m_c, f_orb, e, n, dist).flatten()
 
         should_be_fn_dot = (n * f_orb)**2 * h0**2 / hc**2
         fn_dot = utils.fn_dot(m_c, f_orb, e, n)

--- a/calcs/utils.py
+++ b/calcs/utils.py
@@ -216,11 +216,11 @@ def determine_stationarity(m_1, m_2, forb_i, t_evol, ecc, stat_tol=1e-2):
                  * t_evol / (5 * c.c**5) * (c.G * m_c)**(5/3) * peters_f(ecc)
 
     # any merged binaries will have a negative inner part
-    merged = inner_part < 0.0
-    inspiral = np.logical_not(merged)
+    inspiral = inner_part >= 0.0
 
     # calculate the change in frequency (set to 10^10 Hz if merged)
-    delta_f = np.where(merged, 1e10 * u.Hz, np.power(inner_part[inspiral], -3/8) - forb_i[inspiral])
+    delta_f = np.repeat(1e10, len(forb_i)) * u.Hz
+    delta_f[inspiral] = np.power(inner_part[inspiral], -3/8) - forb_i[inspiral]
     stationary = delta_f / forb_i <= stat_tol
 
     return stationary

--- a/calcs/utils.py
+++ b/calcs/utils.py
@@ -174,6 +174,7 @@ def c_0(a_i, e_i):
          * (1 + (121/304)*e_i**2)**(-870/2299)
     return c0
 
+
 def determine_stationarity(m_1, m_2, forb_i, t_evol, ecc, stat_tol=1e-2):
     """Determine whether a binary is stationary by checking how
     much its orbital frequency changes over t_evol time
@@ -224,7 +225,8 @@ def determine_stationarity(m_1, m_2, forb_i, t_evol, ecc, stat_tol=1e-2):
     stationary = delta_f / forb_i <= stat_tol
 
     return stationary
-    
+
+
 def fn_dot(m_c, f_orb, e, n):
     """Rate of change of nth frequency of a binary
 


### PR DESCRIPTION
I did a couple of things here

- `Source` class now has extra argument, `interpolate_g`, for whether you want to interpolate g(n,e) or use it straight up
- If True, `Source` will do the interpolation immediately during `__init__` and save the function in `Source.g` (this makes initialisation take ~0.5 seconds now)
    - Fun side effect of this is that users can add their own custom interpolated g(n,e) functions by setting `Source.g` if they want a finer grid
- All SNR functions and strain functions take optional `interpolated_g` argument which is the interpolated function and use it in place of `utils.peters_g`, or if None they just use the proper one
- I also vectorised the SNR functions that use g(n,e) whilst I was at it so this'll be faster even if people don't want interpolation
- Oh and I added `Source.get_h_0_n` and `Source.get_h_c_n` because I wanted them to exist whilst testing so I figured users probably would too :)

EDIT: plus linting! :D