### PR TITLE
Eccentric merger time function

### DIFF
--- a/calcs/evol.py
+++ b/calcs/evol.py
@@ -2,7 +2,7 @@
 
 import calcs.utils as utils
 from numba import jit
-from scipy.integrate import odeint
+from scipy.integrate import odeint, quad
 import numpy as np
 import astropy.units as u
 
@@ -33,8 +33,7 @@ def de_dt(e, times, beta, c_0):
         eccentricity evolution
     """
     dedt = -19/12 * beta/c_0**4 * (e**(29/19)*(1 - e**2)**(3/2)) \
-                                / (1+(121/304)*e**2)**(1181/2299)
-
+        / (1+(121/304)*e**2)**(1181/2299)
     return dedt
 
 
@@ -202,33 +201,109 @@ def get_t_merge_circ(m_1, m_2, f_orb_i):
     return t_merge
 
 
-def get_t_merge_ecc(m_1, m_2, f_orb_i, ecc_i):
-    """Computes the merger time in seconds for a circular binary
-    from Peters 1964
+def get_t_merge_ecc(beta=None, m_1=None, m_2=None,
+                    a_i=None, f_orb_i=None, ecc_i=None,
+                    small_e_tol=1e-2, large_e_tol=1 - 1e-2):
+    """Computes the merger time for a binary using Peters 1964.
+    We use one of Eq. 5.10, 5.14 or the two unlabelled equations
+    after 5.14 in Peters 1964 depending on the eccentricity of
+    the binary.
 
     Params
     ------
-    m_1 : `array`
-        primary mass
+    beta : `float/array`
+        beta(m_1, m_2) from Peters 1964 Eq. 5.9 (if supplied `m_1` and
+        `m_2` are ignored)
 
-    m_2 : `array`
-        secondary mass
+    m_1 : `float/array`
+        primary mass (required if `beta` is None)
 
-    f_orb_i : `array`
-        initial orbital frequency
+    m_2 : `float/array`
+        secondary mass (required if `beta` is None)
 
-    ecc_i : `array`
-        initial eccentricity
+    a_i : `float/array`
+        initial semi major axis (if supplied `f_orb_i` is ignored)
+
+    f_orb_i : `float/array`
+        initial orbital frequency (required if `a_i` is None)
+
+    ecc_i : `float/array`
+        initial eccentricity (if `ecc_i` is known to be 0.0 then use
+        `get_t_merge_circ` instead)
+
+    small_e_tol : `float`
+        eccentricity below which to apply the small e approximation
+        (first unlabelled equation following Eq. 5.14 of Peters 1964)
+
+    large_e_tol : `float`
+        eccentricity above which to apply the large e approximation
+        (second unlabelled equation following Eq. 5.14 of Peters 1964)
 
     Returns
     -------
-    t_merge : `array`
+    t_merge : `float/array`
         merger time
     """
+    # ensure that a_i is supplied or calculated
+    if a_i is None and f_orb_i is None:
+        raise ValueError("Either `a_i` or `f_orb_i` must be supplied")
+    elif a_i is None:
+        a_i = utils.get_a_from_f_orb(f_orb=f_orb_i, m_1=m_1, m_2=m_2)
 
-    a_i = utils.get_a_from_f_orb(f_orb=f_orb_i, m_1=m_1, m_2=m_2)
-    beta = utils.beta(m_1, m_2)
+    # ensure that beta is supplied or calculated
+    if beta is None and (m_1 is None or m_2 is None):
+        raise ValueError("Either `beta` or (`m_1`, `m_2`) must be supplied")
+    elif beta is None:
+        beta = utils.beta(m_1, m_2)
 
-    t_merge = a_i**4 / (4*beta)
+    # calculate c0 from Peters Eq. 5.11
+    c0 = utils.c_0(a_i, ecc_i)
 
+    @jit(nopython=True)
+    def peters_5_14(e):
+        """ merger time from Peters Eq. 5.14 """
+        return np.power(e, 29/19) * np.power(1 + (121/304)*e**2, 1181/2299) \
+            / np.power(1 - e**2, 3/2)
+
+    # case with array of binaries
+    if isinstance(ecc_i, (np.ndarray, list)):
+        # mask eccentricity based on tolerances
+        circular = ecc_i == 0.0
+        small_e = np.logical_and(ecc_i > 0.0, ecc_i < small_e_tol)
+        large_e = ecc_i > large_e_tol
+        other_e = np.logical_and(ecc_i >= small_e_tol, ecc_i <= large_e_tol)
+
+        t_merge = np.zeros(len(ecc_i)) * u.Gyr
+
+        # merger time for circular binaries (Peters Eq. 5.9)
+        t_merge[circular] = a_i[circular]**4 / (4 * beta[circular])
+
+        # merger time for low e binaries (Eq after Peters Eq. 5.14)
+        t_merge[small_e] = c0[small_e]**4 / (4 * beta[small_e]) \
+            * ecc_i[small_e]**(48/19)
+
+        # merger time for high e binaries (2nd Eq after Peters Eq. 5.14)
+        t_merge[large_e] = c0[large_e]**4 / (4 * beta[large_e]) \
+            * ecc_i[large_e]**(48/19) * (768 / 425) \
+            * (1 - ecc_i[large_e]**2)**(-1/2) \
+            * (1 + 121/304 * ecc_i[large_e]**2)**(3480/2299)
+
+        # merger time for general binaries (Peters Eq. 5.14)
+        prefac = ((12 / 19) * c0[other_e]**4 / beta[other_e]).to(u.Gyr)
+        t_merge[other_e] = prefac * [quad(peters_5_14, 0, ecc_i[other_e][i])[0]
+                                     for i in range(len(ecc_i[other_e]))]
+    # case with only one binary
+    else:
+        # conditions as above but for floats instead of arrays
+        if ecc_i == 0.0:
+            t_merge = a_i**4 / (4 * beta)
+        elif ecc_i < small_e_tol:
+            t_merge = c0**4 / (4 * beta) * ecc_i**(48/19)
+        elif ecc_i > large_e_tol:
+            t_merge = c0**4 / (4 * beta) * ecc_i**(48/19) * (768 / 425) \
+                * (1 - ecc_i**2)**(-1/2) \
+                * (1 + 121/304 * ecc_i**2)**(3480/2299)
+        else:
+            t_merge = ((12 / 19) * c0**4 / beta
+                       * quad(peters_5_14, 0, ecc_i)[0])
     return t_merge.to(u.Gyr)

--- a/calcs/evol.py
+++ b/calcs/evol.py
@@ -272,6 +272,10 @@ def get_t_merge_ecc(ecc_i, a_i=None, f_orb_i=None,
     elif beta is None:
         beta = utils.beta(m_1, m_2)
 
+    # shortcut if all binaries are effectively circular
+    if np.all(ecc_i <= small_e_tol):
+        return get_t_merge_circ(beta=beta, a_i=a_i)
+
     # calculate c0 from Peters Eq. 5.11
     c0 = utils.c_0(a_i, ecc_i)
 

--- a/calcs/evol.py
+++ b/calcs/evol.py
@@ -173,7 +173,7 @@ def get_f_and_e(m_1, m_2, f_orb_i, e_i, t_evol, n_step):
 
 
 def get_t_merge_circ(beta=None, m_1=None, m_2=None,
-                    a_i=None, f_orb_i=None):
+                     a_i=None, f_orb_i=None):
     """Computes the merger time for a circular binary using Peters 1964
 
     Params

--- a/calcs/lisa.py
+++ b/calcs/lisa.py
@@ -142,8 +142,9 @@ def power_spectral_density(f, t_obs=4*u.yr, L=2.5e9, fstar=19.09e-3,
             gamma = 1680.
             fk = 1.13e-3
 
-        return 9e-45 * f**(-7/3.) * np.exp(-f**(alpha) + beta * f
-                     * np.sin(kappa * f)) * (1 + np.tanh(gamma * (fk - f)))
+        return 9e-45 * f**(-7/3.) \
+            * np.exp(-f**(alpha) + beta * f * np.sin(kappa * f)) \
+            * (1 + np.tanh(gamma * (fk - f)))
 
     # calculate transfer function (either exactly or with approximation)
     if approximate_R:

--- a/calcs/snr.py
+++ b/calcs/snr.py
@@ -231,7 +231,7 @@ def snr_ecc_evolving(m_1, m_2, f_orb_i, dist, ecc, max_harmonic, t_obs, n_step,
     t_merge = evol.get_t_merge_circ(m_1=m_1,
                                     m_2=m_2,
                                     f_orb_i=f_orb_i)
-    t_evol = np.where(t_merge < t_obs, t_merge, t_obs)
+    t_evol = np.where(t_merge > t_obs, t_merge, t_obs)
     # get f_orb, ecc evolution for each binary one by one
     # since we have to integrate the de/de ode
 

--- a/calcs/snr.py
+++ b/calcs/snr.py
@@ -173,8 +173,8 @@ def snr_circ_evolving(m_1, m_2, f_orb_i, dist, t_obs, n_step,
     h_c_lisa_2 = 4 * (2*f_evol) * h_f_lisa_2
 
     snr = (np.sum(h_c_n_2[:-1] / (h_c_lisa_2[:-1] * f_evol[:-1]) *
-                  (f_evol[1:] - f_evol[:-1]), axis=0))**0.5
-    
+           (f_evol[1:] - f_evol[:-1]), axis=0))**0.5
+
     return snr.decompose()
 
 
@@ -236,7 +236,8 @@ def snr_ecc_evolving(m_1, m_2, f_orb_i, dist, ecc, max_harmonic, t_obs, n_step,
     # since we have to integrate the de/de ode
 
     snr = []
-    for m1, m2, mc, fi, ei, d, t in zip(m_1, m_2, m_c, f_orb_i, ecc, dist, t_evol):
+    for m1, m2, mc, fi, ei, d, t in zip(m_1, m_2, m_c, f_orb_i,
+                                        ecc, dist, t_evol):
         f_evol, e_evol = evol.get_f_and_e(m_1=m1,
                                           m_2=m2,
                                           f_orb_i=fi,
@@ -259,7 +260,9 @@ def snr_ecc_evolving(m_1, m_2, f_orb_i, dist, ecc, max_harmonic, t_obs, n_step,
             h_c_lisa_2 = 4 * (n * f_evol) * h_f_lisa_2
 
             # compute the snr for the nth harmonic
-            snr_n_2.append(np.sum(h_c_n_2[:-1] / (h_c_lisa_2[:-1] * f_evol[:-1]) * (f_evol[1:] - f_evol[:-1])))
+            snr_n_2 = np.sum(h_c_n_2[:-1] / (h_c_lisa_2[:-1] * f_evol[:-1])
+                             * (f_evol[1:] - f_evol[:-1]))
+            snr_n_2.append(snr_n_2)
         snr.append(np.sum(snr_n_2)**0.5)
 
     return snr

--- a/calcs/strain.py
+++ b/calcs/strain.py
@@ -115,7 +115,7 @@ def h_c_n(m_c, f_orb, ecc, n, dist, interpolated_g=None):
     # work out strain for n independent part
     prefac = (2**(5/3) / (3 * np.pi**(4/3)))**(0.5) * c.G**(5/6) / c.c**(3/2)
     n_independent_part = prefac * m_c**(5/6) / dist * f_orb**(-1/6) \
-                                / peters_f(ecc)**(0.5)
+        / peters_f(ecc)**(0.5)
 
     # broadcast to correct shape if necessary
     if n_independent_part.shape != (n_sources, n_harmonics):

--- a/calcs/tests/test_evol.py
+++ b/calcs/tests/test_evol.py
@@ -1,0 +1,40 @@
+import numpy as np
+import calcs.evol as evol
+import unittest
+
+from astropy import units as u
+
+class Test(unittest.TestCase):
+    """Tests that the code is functioning properly"""
+
+    def test_upper_bound(self):
+        """checks that the circular merger time is an upper bound for the
+        true merger time"""
+        n_values = 10000
+
+        m_1 = np.random.uniform(0, 10, n_values) * u.Msun
+        m_2 = np.random.uniform(0, 10, n_values) * u.Msun
+        f_orb = 10**(np.random.uniform(-5, -1, n_values)) * u.Hz
+        e = np.random.uniform(0, 1, n_values)
+
+        circ_time = evol.get_t_merge_circ(m_1=m_1, m_2=m_2, f_orb_i=f_orb)
+        ecc_time = evol.get_t_merge_ecc(m_1=m_1, m_2=m_2,
+                                          f_orb_i=f_orb, ecc_i=e)
+
+        self.assertTrue(np.all(circ_time >= ecc_time))
+
+    def test_circular_case(self):
+        """checks that you get the same value if all binaries are
+        exactly circular"""
+        n_values = 10000
+
+        m_1 = np.random.uniform(0, 10, n_values) * u.Msun
+        m_2 = np.random.uniform(0, 10, n_values) * u.Msun
+        f_orb = 10**(np.random.uniform(-5, -1, n_values)) * u.Hz
+        e = np.repeat(0.0, n_values)
+
+        circ_time = evol.get_t_merge_circ(m_1=m_1, m_2=m_2, f_orb_i=f_orb)
+        ecc_time = evol.get_t_merge_ecc(m_1=m_1, m_2=m_2,
+                                          f_orb_i=f_orb, ecc_i=e)
+
+        self.assertTrue(np.allclose(circ_time, ecc_time))

--- a/calcs/tests/test_evol.py
+++ b/calcs/tests/test_evol.py
@@ -4,6 +4,7 @@ import unittest
 
 from astropy import units as u
 
+
 class Test(unittest.TestCase):
     """Tests that the code is functioning properly"""
 
@@ -19,7 +20,7 @@ class Test(unittest.TestCase):
 
         circ_time = evol.get_t_merge_circ(m_1=m_1, m_2=m_2, f_orb_i=f_orb)
         ecc_time = evol.get_t_merge_ecc(m_1=m_1, m_2=m_2,
-                                          f_orb_i=f_orb, ecc_i=e)
+                                        f_orb_i=f_orb, ecc_i=e)
 
         self.assertTrue(np.all(circ_time >= ecc_time))
 
@@ -35,6 +36,6 @@ class Test(unittest.TestCase):
 
         circ_time = evol.get_t_merge_circ(m_1=m_1, m_2=m_2, f_orb_i=f_orb)
         ecc_time = evol.get_t_merge_ecc(m_1=m_1, m_2=m_2,
-                                          f_orb_i=f_orb, ecc_i=e)
+                                        f_orb_i=f_orb, ecc_i=e)
 
         self.assertTrue(np.allclose(circ_time, ecc_time))

--- a/calcs/tests/test_snrs.py
+++ b/calcs/tests/test_snrs.py
@@ -4,6 +4,7 @@ import unittest
 
 from astropy import units as u
 
+
 class Test(unittest.TestCase):
     """Tests that the code is functioning properly"""
 
@@ -17,5 +18,6 @@ class Test(unittest.TestCase):
         t_obs = 4 * u.yr
 
         snr_circ = snr.snr_circ_stationary(m_c, f_orb, dist, t_obs).decompose()
-        snr_ecc = snr.snr_ecc_stationary(m_c, f_orb, 0.0, dist, t_obs, 25).decompose()
+        snr_ecc = snr.snr_ecc_stationary(m_c, f_orb, 0.0, dist,
+                                         t_obs, 25).decompose()
         self.assertTrue(np.allclose(snr_circ, snr_ecc))

--- a/calcs/tests/test_sources.py
+++ b/calcs/tests/test_sources.py
@@ -6,6 +6,7 @@ import unittest
 
 from astropy import units as u
 
+
 class Test(unittest.TestCase):
     """Tests that the code is functioning properly"""
 
@@ -24,18 +25,18 @@ class Test(unittest.TestCase):
 
         sources = source.Source(m_1=m_1, m_2=m_2, f_orb=f_orb,
                                 ecc=ecc, dist=dist)
-        
+
         # compare snr calculated directly with through Source
         snr_direct = snr.snr_circ_stationary(m_c=m_c, f_orb=f_orb,
                                              dist=dist, t_obs=t_obs)
         snr_source = sources.get_snr()
-        
+
         self.assertTrue(np.allclose(snr_direct, snr_source))
 
         # repeat the same test for eccentric systems
         ecc = np.random.uniform(sources.ecc_tol, 0.1, n_values)
         sources.ecc = ecc
-        
+
         snr_direct = snr.snr_ecc_stationary(m_c=m_c, f_orb=f_orb, ecc=ecc,
                                             dist=dist, t_obs=t_obs,
                                             max_harmonic=10)
@@ -56,6 +57,6 @@ class Test(unittest.TestCase):
         sources = source.Source(m_1=m_1, m_2=m_2, f_orb=f_orb,
                                 ecc=ecc, dist=dist)
         stationary_sources = source.Stationary(m_1=m_1, m_2=m_2, f_orb=f_orb,
-                                ecc=ecc, dist=dist)
+                                               ecc=ecc, dist=dist)
         self.assertTrue(np.allclose(sources.get_snr(),
                                     stationary_sources.get_snr()))

--- a/calcs/tests/test_strains.py
+++ b/calcs/tests/test_strains.py
@@ -5,25 +5,25 @@ import unittest
 
 from astropy import units as u
 
-n_values = 100000
 
-m_c = np.random.uniform(0, 10, n_values) * u.Msun
-dist = np.random.uniform(0, 30, n_values) * u.kpc
-f_orb = 10**(np.random.uniform(-5, -1, n_values)) * u.Hz
-e = np.random.uniform(0, 0.9, n_values)
-n = 2
 class Test(unittest.TestCase):
     """Tests that the code is functioning properly"""
 
     def test_strain_conversion(self):
         """This test checks whether the strain and characteristic strain are
         related as hc^2 = (2 * fn^2 / fn_dot) h0^2"""
+        n_values = 100000
+
+        m_c = np.random.uniform(0, 10, n_values) * u.Msun
+        dist = np.random.uniform(0, 30, n_values) * u.kpc
+        f_orb = 10**(np.random.uniform(-5, -1, n_values)) * u.Hz
+        e = np.random.uniform(0, 0.9, n_values)
+        n = 2
+
         h0 = strain.h_0_n(m_c, f_orb, e, n, dist).flatten()
         hc = strain.h_c_n(m_c, f_orb, e, n, dist).flatten()
 
         should_be_fn_dot = (n * f_orb)**2 * h0**2 / hc**2
         fn_dot = utils.fn_dot(m_c, f_orb, e, n)
 
-        difference = should_be_fn_dot.to(u.Hz / u.yr).round(10) - fn_dot.to(u.Hz / u.yr).round(10)
-
-        self.assertTrue(all(difference.value < 1e-5))
+        self.assertTrue(np.allclose(should_be_fn_dot, fn_dot))

--- a/calcs/tests/test_utils.py
+++ b/calcs/tests/test_utils.py
@@ -1,10 +1,9 @@
 import numpy as np
-import calcs.snr as snr
-import calcs.source as source
 import calcs.utils as utils
 import unittest
 
 from astropy import units as u
+
 
 class Test(unittest.TestCase):
     """Tests that the code is functioning properly"""
@@ -16,7 +15,7 @@ class Test(unittest.TestCase):
         f_orb = 10**(np.random.uniform(-5, -1, n_vals)) * u.Hz
         m_1 = np.random.uniform(0, 50, n_vals) * u.Msun
         m_2 = np.random.uniform(0, 50, n_vals) * u.Msun
-        
+
         # convert frequency to semi-major axis
         a = utils.get_a_from_f_orb(f_orb, m_1, m_2)
 

--- a/calcs/utils.py
+++ b/calcs/utils.py
@@ -46,8 +46,8 @@ def peters_g(n, e):
     """
 
     bracket_1 = jv(n-2, n*e) - 2*e*jv(n-1, n*e) \
-                + 2/n*jv(n, n*e) + 2*e*jv(n+1, n*e) \
-                - jv(n+2, n*e)
+        + 2/n*jv(n, n*e) + 2*e*jv(n+1, n*e) \
+        - jv(n+2, n*e)
     bracket_2 = jv(n-2, n*e) - 2*jv(n, n*e) + jv(n+2, n*e)
     bracket_3 = jv(n, n*e)
 
@@ -170,8 +170,8 @@ def c_0(a_i, e_i):
         c factor in SI units
     """
 
-    c0 = a_i * (1-e_i**2) * e_i**(-12/19) \
-         * (1 + (121/304)*e_i**2)**(-870/2299)
+    c0 = a_i * (1 - e_i**2) * e_i**(-12/19) \
+        * (1 + (121/304)*e_i**2)**(-870/2299)
     return c0
 
 
@@ -214,7 +214,7 @@ def determine_stationarity(m_1, m_2, forb_i, t_evol, ecc, stat_tol=1e-2):
     m_c = chirp_mass(m_1, m_2)
     # calculate the inner part of the final frequency equation
     inner_part = forb_i**(-8/3) - 2**(32/3) * np.pi**(8/3) \
-                 * t_evol / (5 * c.c**5) * (c.G * m_c)**(5/3) * peters_f(ecc)
+        * t_evol / (5 * c.c**5) * (c.G * m_c)**(5/3) * peters_f(ecc)
 
     # any merged binaries will have a negative inner part
     inspiral = inner_part >= 0.0
@@ -251,5 +251,5 @@ def fn_dot(m_c, f_orb, e, n):
         rate of change of nth frequency
     """
     fn_dot = (48 * n) / (5 * np.pi) * (c.G * m_c)**(5/3) / c.c**5 \
-             * (2 * np.pi * f_orb)**(11/3) * peters_f(e)
+        * (2 * np.pi * f_orb)**(11/3) * peters_f(e)
     return fn_dot.to(u.Hz / u.yr)


### PR DESCRIPTION
There are a bunch of files changed because I did some more linting, but since the only major changes occur in two files you should only need to look at **evol.py** and **test_evol.py**.

I implemented `get_t_merge_ecc` so now it will calculate the merger time for any set of binaries regardless of eccentricity. There are four cases: circular (Eq. 5.9), low e approximation (first equation after Eq. 5.14), eccentric (Eq. 5.14) and high e approximation (second equation after Eq. 5.14).

I also made it so that both `get_t_merge_ecc` and `get_t_merge_circ` have flexible input such that you can input `beta` _or_ (`m_1, `m_2`) and `f_orb_i` _or_ `a_i` depending on what you've already calculated.

Plus I added tests that ensure that the circular merger time is always longer and that the eccentric merger time is the same as the circular one if all binaries are circular.