### PR TITLE
SNR fixes and many, maannny tests

### DIFF
--- a/calcs/evol.py
+++ b/calcs/evol.py
@@ -32,8 +32,8 @@ def de_dt(e, times, beta, c_0):
     dedt : `array`
         eccentricity evolution
     """
-    dedt = -19/12 * beta/c_0**4 * (e**(29/19)*(1 - e**2)**(3/2)) \
-        / (1+(121/304)*e**2)**(1181/2299)
+    dedt = -19 / 12 * beta / c_0**4 * (e**(-29 / 19) * (1 - e**2)**(3/2)) \
+        / (1 + (121/304) * e**2)**(1181/2299)
     return dedt
 
 
@@ -104,8 +104,8 @@ def get_e_evol(beta, c_0, ecc_i, times):
     e_evol : `array`
         array of eccentricities evolved for the times provided
     """
-
-    e_evol = odeint(de_dt, ecc_i, times, args=(beta.value, c_0.value))
+    e_evol = odeint(de_dt, ecc_i, times.to(u.s),
+                    args=(beta.to(u.m**4 / u.s).value, c_0.to(u.m).value))
 
     return e_evol.flatten()
 
@@ -145,7 +145,7 @@ def get_f_and_e(m_1, m_2, f_orb_i, e_i, t_evol, n_step):
 
     a_i = utils.get_a_from_f_orb(f_orb=f_orb_i, m_1=m_1, m_2=m_2)
     beta = utils.beta(m_1, m_2)
-    times = np.linspace(0, t_evol, n_step)
+    times = np.linspace(0 * u.s, t_evol, n_step).to(u.s)
 
     # Only treat single eccentric sources, so any cases where
     # len(e_i) > 1 are circular.
@@ -272,8 +272,8 @@ def get_t_merge_ecc(ecc_i, a_i=None, f_orb_i=None,
     elif beta is None:
         beta = utils.beta(m_1, m_2)
 
-    # shortcut if all binaries are effectively circular
-    if np.all(ecc_i <= small_e_tol):
+    # shortcut if all binaries are circular
+    if np.all(ecc_i == 0.0):
         return get_t_merge_circ(beta=beta, a_i=a_i)
 
     # calculate c0 from Peters Eq. 5.11

--- a/calcs/evol.py
+++ b/calcs/evol.py
@@ -199,17 +199,20 @@ def get_t_merge_circ(beta=None, m_1=None, m_2=None,
     t_merge : `float/array`
         merger time
     """
-    # ensure that a_i is supplied or calculated
-    if a_i is None and f_orb_i is None:
-        raise ValueError("Either `a_i` or `f_orb_i` must be supplied")
-    elif a_i is None:
-        a_i = utils.get_a_from_f_orb(f_orb=f_orb_i, m_1=m_1, m_2=m_2)
-
     # ensure that beta is supplied or calculated
     if beta is None and (m_1 is None or m_2 is None):
         raise ValueError("Either `beta` or (`m_1`, `m_2`) must be supplied")
     elif beta is None:
         beta = utils.beta(m_1, m_2)
+
+    # ensure that a_i is supplied or calculated
+    if a_i is None and f_orb_i is None:
+        raise ValueError("Either `a_i` or `f_orb_i` must be supplied")
+    elif a_i is None and (m_1 is None or m_2 is None):
+        raise ValueError("Individual masses `m_1` and `m_2` are required \
+                         if no value of `a_i` is supplied")
+    elif a_i is None:
+        a_i = utils.get_a_from_f_orb(f_orb=f_orb_i, m_1=m_1, m_2=m_2)
 
     # apply Peters 1964 Eq. 5.9
     t_merge = a_i**4 / (4 * beta)
@@ -260,17 +263,20 @@ def get_t_merge_ecc(ecc_i, a_i=None, f_orb_i=None,
     t_merge : `float/array`
         merger time
     """
-    # ensure that a_i is supplied or calculated
-    if a_i is None and f_orb_i is None:
-        raise ValueError("Either `a_i` or `f_orb_i` must be supplied")
-    elif a_i is None:
-        a_i = utils.get_a_from_f_orb(f_orb=f_orb_i, m_1=m_1, m_2=m_2)
-
     # ensure that beta is supplied or calculated
     if beta is None and (m_1 is None or m_2 is None):
         raise ValueError("Either `beta` or (`m_1`, `m_2`) must be supplied")
     elif beta is None:
         beta = utils.beta(m_1, m_2)
+
+    # ensure that a_i is supplied or calculated
+    if a_i is None and f_orb_i is None:
+        raise ValueError("Either `a_i` or `f_orb_i` must be supplied")
+    elif a_i is None and (m_1 is None or m_2 is None):
+        raise ValueError("Individual masses `m_1` and `m_2` are required \
+                         if no value of `a_i` is supplied")
+    elif a_i is None:
+        a_i = utils.get_a_from_f_orb(f_orb=f_orb_i, m_1=m_1, m_2=m_2)
 
     # shortcut if all binaries are circular
     if np.all(ecc_i == 0.0):

--- a/calcs/evol.py
+++ b/calcs/evol.py
@@ -8,7 +8,7 @@ import astropy.units as u
 
 
 @jit
-def de_dt(e, times, beta, c_0):
+def de_dt(e, times, beta, c_0):                             # pragma: no cover
     """Computes the evolution of the eccentricity from the emission
     of gravitational waves following Peters & Mathews 1964
 
@@ -286,7 +286,7 @@ def get_t_merge_ecc(ecc_i, a_i=None, f_orb_i=None,
     c0 = utils.c_0(a_i, ecc_i)
 
     @jit(nopython=True)
-    def peters_5_14(e):
+    def peters_5_14(e):                                 # pragma: no cover
         """ merger time from Peters Eq. 5.14 """
         return np.power(e, 29/19) * np.power(1 + (121/304)*e**2, 1181/2299) \
             / np.power(1 - e**2, 3/2)
@@ -320,10 +320,8 @@ def get_t_merge_ecc(ecc_i, a_i=None, f_orb_i=None,
                                      for i in range(len(ecc_i[other_e]))]
     # case with only one binary
     else:
-        # conditions as above but for floats instead of arrays
-        if ecc_i == 0.0:
-            t_merge = a_i**4 / (4 * beta)
-        elif ecc_i < small_e_tol:
+        # conditions as above (no need for ecc=0.0 since it never reaches here)
+        if ecc_i < small_e_tol:
             t_merge = c0**4 / (4 * beta) * ecc_i**(48/19)
         elif ecc_i > large_e_tol:
             t_merge = c0**4 / (4 * beta) * ecc_i**(48/19) * (768 / 425) \

--- a/calcs/lisa.py
+++ b/calcs/lisa.py
@@ -29,7 +29,7 @@ def load_transfer_function(f, fstar=19.09e-3):
     try:
         with resources.path(package="calcs", resource="R.npy") as path:
             f_R, R = np.load(path)
-    except FileExistsError: # pragma: no cover
+    except FileExistsError:                             # pragma: no cover
         print("WARNING: Can't find transfer function file, \
                         using approximation instead")
         return approximate_transfer_function(f, fstar)
@@ -127,8 +127,8 @@ def power_spectral_density(f, t_obs=4*u.yr, L=2.5e9, fstar=19.09e-3,
         ind = np.abs(t_obs - lengths).argmin()
 
         return 9e-45 * f**(-7/3.) \
-            * np.exp(-f**(alpha[ind]) + beta[ind] * f \
-            * np.sin(kappa[ind] * f)) \
+            * np.exp(-f**(alpha[ind]) + beta[ind] * f
+                     * np.sin(kappa[ind] * f)) \
             * (1 + np.tanh(gamma[ind] * (fk[ind] - f)))
 
     # calculate transfer function (either exactly or with approximation)

--- a/calcs/lisa.py
+++ b/calcs/lisa.py
@@ -115,36 +115,21 @@ def power_spectral_density(f, t_obs=4*u.yr, L=2.5e9, fstar=19.09e-3,
     # galactic confusion noise (Robson+ Eq. 14)
     def Sc(f, t_obs):
 
-        # use parameters from Robson+ 2019 by finding closest number of years
-        years = t_obs.to(u.yr).value
-        if years < 0.75:
-            alpha = 0.133
-            beta = 243.
-            kappa = 482.
-            gamma = 917.
-            fk = 2.58e-3
-        elif years < 1.5:
-            alpha = 0.171
-            beta = 292.
-            kappa = 1020.
-            gamma = 1680.
-            fk = 2.15e-3
-        elif years < 3.0:
-            alpha = 0.165
-            beta = 299.
-            kappa = 611.
-            gamma = 1340.
-            fk = 1.73e-3
-        else:
-            alpha = 0.138
-            beta = -221.
-            kappa = 521.
-            gamma = 1680.
-            fk = 1.13e-3
+        # parameters from Robson+ 2019 Table 1
+        lengths = np.array([0.5, 1.0, 2.0, 4.0]) * u.yr
+        alpha = [0.133, 0.171, 0.165, 0.138]
+        beta = [243.0, 292.0, 299.0, -221.0]
+        kappa = [482.0, 1020.0, 611.0, 521.0]
+        gamma = [917.0, 1680.0, 1340.0, 1680.0]
+        fk = [2.58e-3, 2.15e-3, 1.73e-3, 1.13e-3]
+
+        # find index of the closest length to inputted observation time
+        ind = np.abs(t_obs - lengths).argmin()
 
         return 9e-45 * f**(-7/3.) \
-            * np.exp(-f**(alpha) + beta * f * np.sin(kappa * f)) \
-            * (1 + np.tanh(gamma * (fk - f)))
+            * np.exp(-f**(alpha[ind]) + beta[ind] * f \
+            * np.sin(kappa[ind] * f)) \
+            * (1 + np.tanh(gamma[ind] * (fk[ind] - f)))
 
     # calculate transfer function (either exactly or with approximation)
     if approximate_R:

--- a/calcs/lisa.py
+++ b/calcs/lisa.py
@@ -29,7 +29,7 @@ def load_transfer_function(f, fstar=19.09e-3):
     try:
         with resources.path(package="calcs", resource="R.npy") as path:
             f_R, R = np.load(path)
-    except FileExistsError:
+    except FileExistsError: # pragma: no cover
         print("WARNING: Can't find transfer function file, \
                         using approximation instead")
         return approximate_transfer_function(f, fstar)

--- a/calcs/snr.py
+++ b/calcs/snr.py
@@ -260,7 +260,7 @@ def snr_ecc_evolving(m_1, m_2, f_orb_i, dist, ecc, max_harmonic, t_obs, n_step,
             h_c_lisa_2 = 4 * (n * f_evol)**2 * h_f_lisa_2
 
             # compute the snr for the nth harmonic
-            snr_n_2.append(np.sum(h_c_n_2[:-1] / h_c_lisa_2[:-1] * n * (f_evol[1:] - f_evol[:-1])))
+            snr_n_2.append(np.sum(h_c_n_2.flatten()[:-1] / h_c_lisa_2[:-1] * n * (f_evol[1:] - f_evol[:-1])))
         snr.append(np.sum(snr_n_2)**0.5)
 
     return snr

--- a/calcs/snr.py
+++ b/calcs/snr.py
@@ -175,7 +175,7 @@ def snr_circ_evolving(m_1, m_2, f_orb_i, dist, t_obs, n_step,
     h_c_lisa_2 = 4 * (2 * f_evol)**2 * h_f_lisa_2
 
     snr = np.trapz(y=h_c_n_2 / h_c_lisa_2, x=2 * f_evol, axis=0)**0.5
-    
+
     return snr.decompose()
 
 

--- a/calcs/snr.py
+++ b/calcs/snr.py
@@ -161,19 +161,20 @@ def snr_circ_evolving(m_1, m_2, f_orb_i, dist, t_obs, n_step,
                                       n_step=n_step)
 
     # calculate the characteristic power
-    h_c_n_2 = strain.h_c_n(m_c=m_c,
-                           f_orb=f_evol,
-                           ecc=np.zeros(len(m_c)),
+    h_c_n_2 = strain.h_c_n(m_c=np.tile(m_c, n_step),
+                           f_orb=f_evol.flatten(),
+                           ecc=np.zeros_like(f_evol.flatten()).value,
                            n=2,
-                           dist=dist,
+                           dist=np.tile(dist, n_step),
                            interpolated_g=interpolated_g)**2
+    h_c_n_2 = h_c_n_2.flatten().reshape(n_step, len(m_c))
 
     # calculate the characteristic noise power
     h_f_lisa_2 = lisa.power_spectral_density(f=2 * f_evol, t_obs=t_obs)
-    h_c_lisa_2 = 4 * (2*f_evol) * h_f_lisa_2
+    h_c_lisa_2 = 4 * (2 * f_evol)**2 * h_f_lisa_2
 
-    snr = (np.sum(h_c_n_2[:-1] / (h_c_lisa_2[:-1] * f_evol[:-1]) *
-                  (f_evol[1:] - f_evol[:-1]), axis=0))**0.5
+    snr = (np.sum(h_c_n_2[:-1] / h_c_lisa_2[:-1] *
+                  2 * (f_evol[1:] - f_evol[:-1]), axis=0))**0.5
     
     return snr.decompose()
 
@@ -256,10 +257,10 @@ def snr_ecc_evolving(m_1, m_2, f_orb_i, dist, ecc, max_harmonic, t_obs, n_step,
 
             # calculate the characteristic noise power
             h_f_lisa_2 = lisa.power_spectral_density(f=n * f_evol, t_obs=t_obs)
-            h_c_lisa_2 = 4 * (n * f_evol) * h_f_lisa_2
+            h_c_lisa_2 = 4 * (n * f_evol)**2 * h_f_lisa_2
 
             # compute the snr for the nth harmonic
-            snr_n_2.append(np.sum(h_c_n_2[:-1] / (h_c_lisa_2[:-1] * f_evol[:-1]) * (f_evol[1:] - f_evol[:-1])))
+            snr_n_2.append(np.sum(h_c_n_2[:-1] / h_c_lisa_2[:-1] * n * (f_evol[1:] - f_evol[:-1])))
         snr.append(np.sum(snr_n_2)**0.5)
 
     return snr

--- a/calcs/snr.py
+++ b/calcs/snr.py
@@ -182,8 +182,9 @@ def snr_circ_evolving(m_1, m_2, f_orb_i, dist, t_obs, n_step,
 def snr_ecc_evolving(m_1, m_2, f_orb_i, dist, ecc, max_harmonic, t_obs, n_step,
                      interpolated_g=None):
 
-    """Computes the signal to noise ratio for stationary and
-    eccentric binaries
+    """Computes the signal to noise ratio for evolving and
+    eccentric binaries. This function will not work for exactly
+    circular (ecc = 0.0) binaries.
 
 
     Params
@@ -233,7 +234,7 @@ def snr_ecc_evolving(m_1, m_2, f_orb_i, dist, ecc, max_harmonic, t_obs, n_step,
                                    m_2=m_2,
                                    f_orb_i=f_orb_i,
                                    ecc_i=ecc)
-    t_evol = np.minimum(t_merge * 0.99, t_obs).to(u.s)
+    t_evol = np.minimum(t_merge, t_obs).to(u.s)
     # get f_orb, ecc evolution for each binary one by one
     # since we have to integrate the de/de ode
 
@@ -245,6 +246,10 @@ def snr_ecc_evolving(m_1, m_2, f_orb_i, dist, ecc, max_harmonic, t_obs, n_step,
                                           e_i=ecc[i],
                                           t_evol=t_evol[i],
                                           n_step=n_step)
+
+        merged = np.isnan(e_evol)
+        e_evol[merged] = 0.0
+        f_evol[merged] = 1 * u.Hz
 
         # calculate the characteristic power
         snr_n_2 = []

--- a/calcs/strain.py
+++ b/calcs/strain.py
@@ -131,7 +131,7 @@ def h_c_n(m_c, f_orb, ecc, n, dist, interpolated_g=None):
         # unsort the output array if there is more than one eccentricity
         if isinstance(ecc, (np.ndarray, list)) and len(ecc) > 1:
             g_vals = g_vals[np.argsort(ecc).argsort()]
-        n_dependent_part = (g_vals / N)**(0.5) / N
+        n_dependent_part = (g_vals / N)**(0.5)
 
     h_c = n_independent_part * n_dependent_part
     return h_c

--- a/calcs/tests/test_evol.py
+++ b/calcs/tests/test_evol.py
@@ -97,3 +97,27 @@ class Test(unittest.TestCase):
         except ValueError:
             no_worries = False
         self.assertFalse(no_worries)
+
+    def test_t_merge_special_cases(self):
+        """checks that t_merge_ecc operates properly with exactly circular
+        binaries and also single sources"""
+
+        n_values = 10000
+        beta = np.random.uniform(10, 50, n_values) * u.AU**4 / u.Gyr
+        a_i = np.random.uniform(0.01, 0.1, n_values) * u.AU
+
+        # ensure you get the same value no matter which function you use
+        circ_time = evol.get_t_merge_circ(beta=beta, a_i=a_i).to(u.yr)
+        ecc_time = evol.get_t_merge_ecc(beta=beta, a_i=a_i,
+                                        ecc_i=np.zeros(len(a_i))).to(u.yr)
+
+        self.assertTrue(np.all(circ_time == ecc_time))
+
+        beta = np.random.uniform(10, 50, 1) * u.AU**4 / u.Gyr
+        a_i = np.random.uniform(0.01, 0.1, 1) * u.AU
+
+        for e in [0.0, 0.005, 0.5, 0.999]:
+            ecc_i = np.array([e])
+            array_time = evol.get_t_merge_ecc(beta=beta, a_i=a_i, ecc_i=ecc_i).to(u.yr)
+            single_time = evol.get_t_merge_ecc(beta=beta[0], a_i=a_i[0], ecc_i=ecc_i[0]).to(u.yr)
+            self.assertTrue(array_time[0] == single_time)

--- a/calcs/tests/test_evol.py
+++ b/calcs/tests/test_evol.py
@@ -39,3 +39,61 @@ class Test(unittest.TestCase):
                                         f_orb_i=f_orb, ecc_i=e)
 
         self.assertTrue(np.allclose(circ_time, ecc_time))
+
+    def test_t_merge_circ_bad_input(self):
+        """checks that the t_merge circ function handles bad input well"""
+        # missing masses
+        no_worries = True
+        try:
+            evol.get_t_merge_circ(beta=None, m_1=None, m_2=None,
+                                  f_orb_i=1e-3 * u.Hz)
+        except ValueError:
+            no_worries = False
+        self.assertFalse(no_worries)
+
+        # missing individual masses and no a_i
+        no_worries = True
+        try:
+            evol.get_t_merge_circ(beta=10 * u.m**4 / u.s,
+                                  f_orb_i=1e-3 * u.Hz, a_i=None)
+        except ValueError:
+            no_worries = False
+        self.assertFalse(no_worries)
+
+        # missing frequency and separation
+        no_worries = True
+        try:
+            evol.get_t_merge_circ(m_1=10 * u.Msun, m_2=10 * u.Msun,
+                                  f_orb_i=None, a_i=None)
+        except ValueError:
+            no_worries = False
+        self.assertFalse(no_worries)
+
+    def test_t_merge_ecc_bad_input(self):
+        """checks that the t_merge ecc function handles bad input well"""
+        # missing masses
+        no_worries = True
+        try:
+            evol.get_t_merge_ecc(beta=None, m_1=None, m_2=None,
+                                 f_orb_i=1e-3 * u.Hz, ecc_i=0.0)
+        except ValueError:
+            no_worries = False
+        self.assertFalse(no_worries)
+
+        # missing individual masses and no a_i
+        no_worries = True
+        try:
+            evol.get_t_merge_ecc(beta=10 * u.m**4 / u.s,
+                                 f_orb_i=1e-3 * u.Hz, a_i=None, ecc_i=0.0)
+        except ValueError:
+            no_worries = False
+        self.assertFalse(no_worries)
+
+        # missing frequency and separation
+        no_worries = True
+        try:
+            evol.get_t_merge_ecc(m_1=10 * u.Msun, m_2=10 * u.Msun,
+                                 f_orb_i=None, a_i=None, ecc_i=0.0)
+        except ValueError:
+            no_worries = False
+        self.assertFalse(no_worries)

--- a/calcs/tests/test_evol.py
+++ b/calcs/tests/test_evol.py
@@ -118,6 +118,8 @@ class Test(unittest.TestCase):
 
         for e in [0.0, 0.005, 0.5, 0.999]:
             ecc_i = np.array([e])
-            array_time = evol.get_t_merge_ecc(beta=beta, a_i=a_i, ecc_i=ecc_i).to(u.yr)
-            single_time = evol.get_t_merge_ecc(beta=beta[0], a_i=a_i[0], ecc_i=ecc_i[0]).to(u.yr)
+            array_time = evol.get_t_merge_ecc(beta=beta, a_i=a_i,
+                                              ecc_i=ecc_i).to(u.yr)
+            single_time = evol.get_t_merge_ecc(beta=beta[0], a_i=a_i[0],
+                                               ecc_i=ecc_i[0]).to(u.yr)
             self.assertTrue(array_time[0] == single_time)

--- a/calcs/tests/test_lisa.py
+++ b/calcs/tests/test_lisa.py
@@ -17,3 +17,20 @@ class Test(unittest.TestCase):
         approx = lisa.power_spectral_density(frequencies, approximate_R=False)
 
         self.assertTrue(np.allclose(exact, approx))
+
+    def test_confusion_noise(self):
+        """check that confusion noise is doing logical things"""
+        frequencies = np.logspace(-6, 0, 10000) * u.Hz
+
+        confused = lisa.power_spectral_density(frequencies,
+                                               include_confusion_noise=True)
+        lucid = lisa.power_spectral_density(frequencies, 
+                                            include_confusion_noise=False)
+
+        # ensure confusion noise only adds to noise
+        self.assertTrue(np.all(confused >= lucid))
+
+        # ensure that it doesn't affect things at low or high frequency
+        safe = np.logical_or(frequencies < 1e-4 * u.Hz,
+                                     frequencies > 1e-2 * u.Hz)
+        self.assertTrue(np.allclose(confused[safe], lucid[safe]))

--- a/calcs/tests/test_lisa.py
+++ b/calcs/tests/test_lisa.py
@@ -34,3 +34,22 @@ class Test(unittest.TestCase):
         safe = np.logical_or(frequencies < 1e-4 * u.Hz,
                                      frequencies > 1e-2 * u.Hz)
         self.assertTrue(np.allclose(confused[safe], lucid[safe]))
+
+    def test_mission_length_effect(self):
+        """check that increasing the mission length isn't changing
+        anything far from confusion noise"""
+        frequencies = np.logspace(-6, 0, 100) * u.Hz
+
+        # compute same curve with various mission length
+        smol = lisa.power_spectral_density(frequencies, t_obs=0.5 * u.yr)
+        teeny = lisa.power_spectral_density(frequencies, t_obs=1.0 * u.yr)
+        little = lisa.power_spectral_density(frequencies, t_obs=2.0 * u.yr)
+        regular = lisa.power_spectral_density(frequencies, t_obs=4.5 * u.yr)
+        looonngg = lisa.power_spectral_density(frequencies, t_obs=10.0 * u.yr)
+        noises = [smol, teeny, little, regular, looonngg]
+
+        # ensure that a shorter mission length never decreases the noise
+        for noise in noises:
+            above = noise > regular
+            close = np.isclose(noise, regular, atol=1e-39)
+            self.assertTrue(np.logical_or(above, close).all())

--- a/calcs/tests/test_lisa.py
+++ b/calcs/tests/test_lisa.py
@@ -1,0 +1,19 @@
+import numpy as np
+import calcs.lisa as lisa
+import calcs.utils as utils
+import unittest
+
+from astropy import units as u
+
+
+class Test(unittest.TestCase):
+    """Tests that the code is functioning properly"""
+
+    def test_R_approximation(self):
+        """check that the R approximation works for low frequencies"""
+        frequencies = np.logspace(-6, -2, 10000) * u.Hz
+
+        exact = lisa.power_spectral_density(frequencies, approximate_R=True)
+        approx = lisa.power_spectral_density(frequencies, approximate_R=False)
+
+        self.assertTrue(np.allclose(exact, approx))

--- a/calcs/tests/test_lisa.py
+++ b/calcs/tests/test_lisa.py
@@ -1,8 +1,6 @@
 import numpy as np
 import calcs.lisa as lisa
-import calcs.utils as utils
 import unittest
-
 from astropy import units as u
 
 
@@ -24,7 +22,7 @@ class Test(unittest.TestCase):
 
         confused = lisa.power_spectral_density(frequencies,
                                                include_confusion_noise=True)
-        lucid = lisa.power_spectral_density(frequencies, 
+        lucid = lisa.power_spectral_density(frequencies,
                                             include_confusion_noise=False)
 
         # ensure confusion noise only adds to noise
@@ -32,7 +30,7 @@ class Test(unittest.TestCase):
 
         # ensure that it doesn't affect things at low or high frequency
         safe = np.logical_or(frequencies < 1e-4 * u.Hz,
-                                     frequencies > 1e-2 * u.Hz)
+                             frequencies > 1e-2 * u.Hz)
         self.assertTrue(np.allclose(confused[safe], lucid[safe]))
 
     def test_mission_length_effect(self):

--- a/calcs/tests/test_snrs.py
+++ b/calcs/tests/test_snrs.py
@@ -1,5 +1,6 @@
 import numpy as np
 import calcs.snr as snr
+import calcs.utils as utils
 import unittest
 
 from astropy import units as u
@@ -8,16 +9,39 @@ from astropy import units as u
 class Test(unittest.TestCase):
     """Tests that the code is functioning properly"""
 
-    def test_circular_vs_eccentric_snr(self):
+    def test_circ_vs_ecc_stationary(self):
         """check whether the eccentric snr equation gives the same results
-        as the circular one for circular binaries"""
+        as the circular one for circular stationary binaries"""
         n_values = 100000
         m_c = np.random.uniform(0, 10, n_values) * u.Msun
         dist = np.random.uniform(0, 30, n_values) * u.kpc
         f_orb = 10**(np.random.uniform(-5, -1, n_values)) * u.Hz
         t_obs = 4 * u.yr
 
-        snr_circ = snr.snr_circ_stationary(m_c, f_orb, dist, t_obs).decompose()
-        snr_ecc = snr.snr_ecc_stationary(m_c, f_orb, 0.0, dist,
-                                         t_obs, 25).decompose()
+        snr_circ = snr.snr_circ_stationary(m_c=m_c, f_orb=f_orb,
+                                           dist=dist, t_obs=t_obs)
+        snr_ecc = snr.snr_ecc_stationary(m_c=m_c, f_orb=f_orb,
+                                         ecc=0.0, dist=dist,
+                                         t_obs=t_obs, max_harmonic=3)
+        self.assertTrue(np.allclose(snr_circ, snr_ecc))
+
+    def test_stat_vs_evol_eccentric(self):
+        """check whether the evolving snr equation gives the same results
+        as the stationary one for eccentric stationary binaries"""
+        n_values = 100
+        m_1 = np.random.uniform(0, 10, n_values) * u.Msun
+        m_2 = np.random.uniform(0, 10, n_values) * u.Msun
+        m_c = utils.chirp_mass(m_1, m_2)
+        dist = np.random.uniform(0, 30, n_values) * u.kpc
+        f_orb = 10**(np.random.uniform(-6, -4, n_values)) * u.Hz
+        ecc = np.random.uniform(0.1, 0.15, n_values)
+        t_obs = 4 * u.yr
+
+        snr_circ = snr.snr_ecc_stationary(m_c=m_c, ecc=ecc,
+                                         f_orb=f_orb, dist=dist,
+                                         t_obs=t_obs, max_harmonic=10)
+        snr_ecc = snr.snr_ecc_evolving(m_1=m_1, m_2=m_2, ecc=ecc,
+                                       f_orb_i=f_orb, dist=dist, n_step=100,
+                                       t_obs=t_obs, max_harmonic=10)
+
         self.assertTrue(np.allclose(snr_circ, snr_ecc))

--- a/calcs/tests/test_snrs.py
+++ b/calcs/tests/test_snrs.py
@@ -38,8 +38,8 @@ class Test(unittest.TestCase):
         t_obs = 4 * u.yr
 
         snr_circ = snr.snr_ecc_stationary(m_c=m_c, ecc=ecc,
-                                         f_orb=f_orb, dist=dist,
-                                         t_obs=t_obs, max_harmonic=10)
+                                          f_orb=f_orb, dist=dist,
+                                          t_obs=t_obs, max_harmonic=10)
         snr_ecc = snr.snr_ecc_evolving(m_1=m_1, m_2=m_2, ecc=ecc,
                                        f_orb_i=f_orb, dist=dist, n_step=100,
                                        t_obs=t_obs, max_harmonic=10)

--- a/calcs/tests/test_sources.py
+++ b/calcs/tests/test_sources.py
@@ -48,7 +48,6 @@ class Test(unittest.TestCase):
     def test_source_strain(self):
         """check that source calculate strain correctly"""
         n_values = 500
-        t_obs = 4 * u.yr
         m_1 = np.random.uniform(0, 10, n_values) * u.Msun
         m_2 = np.random.uniform(0, 10, n_values) * u.Msun
         m_c = utils.chirp_mass(m_1, m_2)
@@ -69,7 +68,7 @@ class Test(unittest.TestCase):
         true_char_strain = strain.h_c_n(m_c=m_c, f_orb=f_orb, ecc=ecc,
                                         n=[1, 2, 3], dist=dist)
 
-        self.assertTrue(np.all(source_char_strain == source_char_strain))
+        self.assertTrue(np.all(source_char_strain == true_char_strain))
 
     def test_stationary_subclass(self):
         # create random (circular/stationary) binaries

--- a/calcs/tests/test_sources.py
+++ b/calcs/tests/test_sources.py
@@ -29,7 +29,7 @@ class Test(unittest.TestCase):
         # compare snr calculated directly with through Source
         snr_direct = snr.snr_circ_stationary(m_c=m_c, f_orb=f_orb,
                                              dist=dist, t_obs=t_obs)
-        snr_source = sources.get_snr()
+        snr_source = sources.get_snr(verbose=True)
 
         self.assertTrue(np.allclose(snr_direct, snr_source))
 
@@ -40,7 +40,7 @@ class Test(unittest.TestCase):
         snr_direct = snr.snr_ecc_stationary(m_c=m_c, f_orb=f_orb, ecc=ecc,
                                             dist=dist, t_obs=t_obs,
                                             max_harmonic=10)
-        snr_source = sources.get_snr()
+        snr_source = sources.get_snr(verbose=True)
 
         self.assertTrue(np.allclose(snr_direct, snr_source))
 
@@ -58,13 +58,13 @@ class Test(unittest.TestCase):
                                 ecc=ecc, dist=dist)
         stationary_sources = source.Stationary(m_1=m_1, m_2=m_2, f_orb=f_orb,
                                                ecc=ecc, dist=dist)
-        self.assertTrue(np.allclose(sources.get_snr(),
-                                    stationary_sources.get_snr()))
+        self.assertTrue(np.allclose(sources.get_snr(verbose=True),
+                                    stationary_sources.get_snr(verbose=True)))
 
     def test_interpolated_g(self):
         """checks that the interpolation of g(n,e) is not producing
         any large errors"""
-        # create random (circular/stationary) binaries
+        # create random binaries
         n_values = 50
         m_1 = np.random.uniform(0, 10, n_values) * u.Msun
         m_2 = np.random.uniform(0, 10, n_values) * u.Msun
@@ -79,8 +79,8 @@ class Test(unittest.TestCase):
         sources = source.Source(m_1=m_1, m_2=m_2, f_orb=f_orb,
                                 ecc=ecc, dist=dist, interpolate_g=False)
 
-        interp_snr = sources_interp.get_snr()
-        snr = sources.get_snr()
+        interp_snr = sources_interp.get_snr(verbose=True)
+        snr = sources.get_snr(verbose=True)
 
         self.assertTrue(np.allclose(interp_snr, snr, atol=1e-2))
 
@@ -113,11 +113,8 @@ class Test(unittest.TestCase):
 
         # try creating sources with only single source (should be fine)
         no_worries = True
-        try:
-            sources = source.Source(m_1=1 * u.Msun, m_2=1 * u.Msun,
-                                    ecc=0.1, dist=8 * u.kpc, f_orb=3e-4 * u.Hz)
-        except:
-            no_worries = False
+        sources = source.Source(m_1=1 * u.Msun, m_2=1 * u.Msun,
+                                ecc=0.1, dist=8 * u.kpc, f_orb=3e-4 * u.Hz)
         self.assertTrue(no_worries)
 
         # try creating sources with different length arrays

--- a/calcs/tests/test_sources.py
+++ b/calcs/tests/test_sources.py
@@ -195,7 +195,7 @@ class Test(unittest.TestCase):
         interp_snr = sources_interp.get_snr(verbose=True)
         snr = sources.get_snr(verbose=True)
 
-        self.assertTrue(np.allclose(interp_snr, snr, atol=1e-2))
+        self.assertTrue(np.allclose(interp_snr, snr, atol=1e-1))
 
     def test_bad_input(self):
         """checks that Source handles bad input well"""

--- a/calcs/tests/test_sources.py
+++ b/calcs/tests/test_sources.py
@@ -60,3 +60,26 @@ class Test(unittest.TestCase):
                                                ecc=ecc, dist=dist)
         self.assertTrue(np.allclose(sources.get_snr(),
                                     stationary_sources.get_snr()))
+
+    def test_interpolated_g(self):
+        """checks that the interpolation of g(n,e) is not producing
+        any large errors"""
+        # create random (circular/stationary) binaries
+        n_values = 50
+        m_1 = np.random.uniform(0, 10, n_values) * u.Msun
+        m_2 = np.random.uniform(0, 10, n_values) * u.Msun
+        dist = np.random.uniform(0, 30, n_values) * u.kpc
+        f_orb = 10**(np.random.uniform(-5, -1, n_values)) * u.Hz
+        ecc = np.random.uniform(0.0, 0.9, n_values)
+
+        # compare snr calculated directly with through Source
+        sources_interp = source.Source(m_1=m_1, m_2=m_2, f_orb=f_orb,
+                                       ecc=ecc, dist=dist, interpolate_g=True)
+
+        sources = source.Source(m_1=m_1, m_2=m_2, f_orb=f_orb,
+                                ecc=ecc, dist=dist, interpolate_g=False)
+
+        interp_snr = sources_interp.get_snr()
+        snr = sources.get_snr()
+
+        self.assertTrue(np.allclose(interp_snr, snr, atol=1e-2))

--- a/calcs/tests/test_sources.py
+++ b/calcs/tests/test_sources.py
@@ -1,6 +1,7 @@
 import numpy as np
 import calcs.snr as snr
 import calcs.source as source
+import calcs.strain as strain
 import calcs.utils as utils
 import unittest
 
@@ -44,7 +45,33 @@ class Test(unittest.TestCase):
 
         self.assertTrue(np.allclose(snr_direct, snr_source))
 
-    def test_subclasses(self):
+    def test_source_strain(self):
+        """check that source calculate strain correctly"""
+        n_values = 500
+        t_obs = 4 * u.yr
+        m_1 = np.random.uniform(0, 10, n_values) * u.Msun
+        m_2 = np.random.uniform(0, 10, n_values) * u.Msun
+        m_c = utils.chirp_mass(m_1, m_2)
+        dist = np.random.uniform(0, 30, n_values) * u.kpc
+        f_orb = 10**(np.random.uniform(-5, -4, n_values)) * u.Hz
+        ecc = np.repeat(0.0, n_values)
+
+        sources = source.Source(m_1=m_1, m_2=m_2, f_orb=f_orb,
+                                ecc=ecc, dist=dist, interpolate_g=False)
+
+        source_strain = sources.get_h_0_n([1, 2, 3])
+        true_strain = strain.h_0_n(m_c=m_c, f_orb=f_orb, ecc=ecc,
+                                   n=[1, 2, 3], dist=dist)
+
+        self.assertTrue(np.all(source_strain == true_strain))
+
+        source_char_strain = sources.get_h_c_n([1, 2, 3])
+        true_char_strain = strain.h_c_n(m_c=m_c, f_orb=f_orb, ecc=ecc,
+                                        n=[1, 2, 3], dist=dist)
+
+        self.assertTrue(np.all(source_char_strain == source_char_strain))
+
+    def test_stationary_subclass(self):
         # create random (circular/stationary) binaries
         n_values = 500
         m_1 = np.random.uniform(0, 10, n_values) * u.Msun
@@ -60,6 +87,92 @@ class Test(unittest.TestCase):
                                                ecc=ecc, dist=dist)
         self.assertTrue(np.allclose(sources.get_snr(verbose=True),
                                     stationary_sources.get_snr(verbose=True)))
+
+    def test_evolving_subclass(self):
+        # create random (circular/evolving) binaries
+        n_values = 500
+        m_1 = np.random.uniform(5, 10, n_values) * u.Msun
+        m_2 = np.random.uniform(5, 10, n_values) * u.Msun
+        dist = np.random.uniform(0, 30, n_values) * u.kpc
+        f_orb = 10**(np.random.uniform(-1.2, -0.5, n_values)) * u.Hz
+        ecc = np.repeat(0.0, n_values)
+
+        # compare snr calculated directly with through Source
+        sources = source.Source(m_1=m_1, m_2=m_2, f_orb=f_orb,
+                                ecc=ecc, dist=dist)
+        evolving_sources = source.Evolving(m_1=m_1, m_2=m_2, f_orb=f_orb,
+                                           ecc=ecc, dist=dist)
+        self.assertTrue(np.allclose(sources.get_snr(verbose=True),
+                                    evolving_sources.get_snr(verbose=True)))
+
+    def test_masks(self):
+        """checks that the masks are being produced correctly"""
+        n_values = 10000
+        dist = np.random.uniform(0, 30, n_values) * u.kpc
+
+        # all stationary and circular
+        m_1 = np.random.uniform(0, 10, n_values) * u.Msun
+        m_2 = np.random.uniform(0, 10, n_values) * u.Msun
+        f_orb = 10**(np.random.uniform(-7, -5, n_values)) * u.Hz
+        ecc = np.random.uniform(0.0, 0.0, n_values)
+
+        sources = source.Source(m_1=m_1, m_2=m_2, ecc=ecc,
+                                dist=dist, f_orb=f_orb, interpolate_g=False)
+        self.assertTrue(sources.get_source_mask(circular=True,
+                                                stationary=True).all())
+
+        # all stationary and eccentric
+        m_1 = np.random.uniform(0, 10, n_values) * u.Msun
+        m_2 = np.random.uniform(0, 10, n_values) * u.Msun
+        f_orb = 10**(np.random.uniform(-7, -5, n_values)) * u.Hz
+        ecc = np.random.uniform(0.1, 0.2, n_values)
+
+        sources = source.Source(m_1=m_1, m_2=m_2, ecc=ecc,
+                                dist=dist, f_orb=f_orb, interpolate_g=False)
+        self.assertTrue(sources.get_source_mask(circular=False,
+                                                stationary=True).all())
+
+        # all evolving and circular
+        m_1 = np.random.uniform(5, 10, n_values) * u.Msun
+        m_2 = np.random.uniform(5, 10, n_values) * u.Msun
+        f_orb = 10**(np.random.uniform(-1, 0, n_values)) * u.Hz
+        ecc = np.random.uniform(0.0, 0.0, n_values)
+
+        sources = source.Source(m_1=m_1, m_2=m_2, ecc=ecc,
+                                dist=dist, f_orb=f_orb, interpolate_g=False)
+        self.assertTrue(sources.get_source_mask(circular=True,
+                                                stationary=False).all())
+
+        # all evolving and eccentric
+        m_1 = np.random.uniform(5, 10, n_values) * u.Msun
+        m_2 = np.random.uniform(5, 10, n_values) * u.Msun
+        f_orb = 10**(np.random.uniform(-1, 0, n_values)) * u.Hz
+        ecc = np.random.uniform(0.1, 0.9, n_values)
+
+        sources = source.Source(m_1=m_1, m_2=m_2, ecc=ecc,
+                                dist=dist, f_orb=f_orb, interpolate_g=False)
+        self.assertTrue(sources.get_source_mask(circular=False,
+                                                stationary=False).all())
+
+        # check it works fine if you give Nones
+        self.assertTrue(sources.get_source_mask(circular=None,
+                                                stationary=None).all())
+
+        # check it crashes if you give nonesense input
+        no_worries = True
+        try:
+            sources.get_source_mask(circular="ridiculous input")
+        except ValueError:
+            no_worries = False
+        self.assertFalse(no_worries)
+
+        # check it crashes if you give nonesense input
+        no_worries = True
+        try:
+            sources.get_source_mask(stationary="ridiculous input")
+        except ValueError:
+            no_worries = False
+        self.assertFalse(no_worries)
 
     def test_interpolated_g(self):
         """checks that the interpolation of g(n,e) is not producing
@@ -97,7 +210,7 @@ class Test(unittest.TestCase):
         # try creating sources with no f_orb or a
         no_worries = True
         try:
-            sources = source.Source(m_1=m_1, m_2=m_2, ecc=ecc, dist=dist)
+            source.Source(m_1=m_1, m_2=m_2, ecc=ecc, dist=dist)
         except ValueError:
             no_worries = False
         self.assertFalse(no_worries)
@@ -105,24 +218,24 @@ class Test(unittest.TestCase):
         # try creating sources with no units
         no_worries = True
         try:
-            sources = source.Source(m_1=m_1, m_2=m_2, ecc=ecc,
-                                    dist=dist.value, f_orb=f_orb)
+            source.Source(m_1=m_1, m_2=m_2, ecc=ecc,
+                          dist=dist.value, f_orb=f_orb)
         except AssertionError:
             no_worries = False
         self.assertFalse(no_worries)
 
         # try creating sources with only single source (should be fine)
         no_worries = True
-        sources = source.Source(m_1=1 * u.Msun, m_2=1 * u.Msun,
-                                ecc=0.1, dist=8 * u.kpc, f_orb=3e-4 * u.Hz)
+        source.Source(m_1=1 * u.Msun, m_2=1 * u.Msun,
+                      ecc=0.1, dist=8 * u.kpc, f_orb=3e-4 * u.Hz)
         self.assertTrue(no_worries)
 
         # try creating sources with different length arrays
         no_worries = True
         dist = np.append(dist, 8 * u.kpc)
         try:
-            sources = source.Source(m_1=m_1, m_2=m_2, ecc=ecc,
-                                    dist=dist, f_orb=f_orb)
+            source.Source(m_1=m_1, m_2=m_2, ecc=ecc,
+                          dist=dist, f_orb=f_orb)
         except ValueError:
             no_worries = False
         self.assertFalse(no_worries)

--- a/calcs/tests/test_sources.py
+++ b/calcs/tests/test_sources.py
@@ -83,3 +83,49 @@ class Test(unittest.TestCase):
         snr = sources.get_snr()
 
         self.assertTrue(np.allclose(interp_snr, snr, atol=1e-2))
+
+    def test_bad_input(self):
+        """checks that Source handles bad input well"""
+
+        n_values = 10
+        m_1 = np.random.uniform(0, 10, n_values) * u.Msun
+        m_2 = np.random.uniform(0, 10, n_values) * u.Msun
+        ecc = np.random.uniform(0.0, 1.0, n_values)
+        dist = np.random.uniform(0, 10, n_values) * u.kpc
+        f_orb = 10**(np.random.uniform(-5, -1, n_values)) * u.Hz
+
+        # try creating sources with no f_orb or a
+        no_worries = True
+        try:
+            sources = source.Source(m_1=m_1, m_2=m_2, ecc=ecc, dist=dist)
+        except ValueError:
+            no_worries = False
+        self.assertFalse(no_worries)
+
+        # try creating sources with no units
+        no_worries = True
+        try:
+            sources = source.Source(m_1=m_1, m_2=m_2, ecc=ecc,
+                                    dist=dist.value, f_orb=f_orb)
+        except AssertionError:
+            no_worries = False
+        self.assertFalse(no_worries)
+
+        # try creating sources with only single source (should be fine)
+        no_worries = True
+        try:
+            sources = source.Source(m_1=1 * u.Msun, m_2=1 * u.Msun,
+                                    ecc=0.1, dist=8 * u.kpc, f_orb=3e-4 * u.Hz)
+        except:
+            no_worries = False
+        self.assertTrue(no_worries)
+
+        # try creating sources with different length arrays
+        no_worries = True
+        dist = np.append(dist, 8 * u.kpc)
+        try:
+            sources = source.Source(m_1=m_1, m_2=m_2, ecc=ecc,
+                                    dist=dist, f_orb=f_orb)
+        except ValueError:
+            no_worries = False
+        self.assertFalse(no_worries)


### PR DESCRIPTION
With this PR I can confirm we have matching results for SNRs of any type of source!! I made two bug fixes but otherwise we nailed it 😎 

I have also added a _bunch_ of tests such that I believe we should now have full coverage! You'll be glad to know that this was useful and actually pointed out a couple of corner cases to me. Here's a list of them if you'd rather read this than the code 🙃 

**test_evol.py**
- Test that it doesn't freak out when I give dodgy input to get_t_merge_circ/ecc
- Ensure special cases of get_t_merge_ecc (single source/all circular) do what they should

**test_lisa.py**
- Ensure R approximation only affects the highest frequencies
- Ensure confusion noise only adds to the sensitivity curve and only in the correct frequency range
- Make sure changing the mission length to shorter times only increases the noise

**test_snrs.py**
- Check that the stationary and evolving snr functions give the same value for stationary binaries

**test_sources.py**
- make sure the strain getters match the regular functions
- check the evolving subclass gives the same results as the regular Source class for evolving binaries
- make sure the get_source_mask masks are all what they should be for the various options and that it handles bad input properly
- test that interpolating the g(n,e) function gives roughly the same snr values
- check the class can handle bad input (lack of units, mismatched length arrays, missing parameters)

Whew! That is rather satisfying :) 